### PR TITLE
fix (share picker): disable setting default share target

### DIFF
--- a/app/src/main/java/com/leavjenn/hews/ui/CommentsActivity.java
+++ b/app/src/main/java/com/leavjenn/hews/ui/CommentsActivity.java
@@ -121,7 +121,7 @@ public class CommentsActivity extends AppCompatActivity {
                         + mPost.getId();
                 sendIntent.putExtra(Intent.EXTRA_TEXT, commentUrl);
                 sendIntent.setType("text/plain");
-                startActivity(sendIntent);
+                startActivity(Intent.createChooser(sendIntent, getString(R.string.share_with)));
                 break;
 
             case R.id.action_display:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="title_activity_comments">CommentsActivity</string>
     <string name="open_with_hn">Open With Necker Hews</string>
     <string name="no_comment_promt">No comment yet</string>
+    <string name="share_with">Share with</string>
 
     <!-- Nav drawer -->
     <string name="nav_top_story">Top</string>


### PR DESCRIPTION
As outlined in http://developer.android.com/training/sharing/send.html#send-text-content always showing the share-picker is the preferred way of doing this, since the app the user wants to share to can very quite a lot.
