### PR TITLE
fixed (shadow): add toolbar shadow for api < 21

### DIFF
--- a/app/src/main/res/drawable/elevation_compat.xml
+++ b/app/src/main/res/drawable/elevation_compat.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="270"
+        android:endColor="@android:color/transparent"
+        android:startColor="#50000000" />
+</shape>

--- a/app/src/main/res/layout/activity_comments.xml
+++ b/app/src/main/res/layout/activity_comments.xml
@@ -29,6 +29,13 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="4dp"
+            android:background="@drawable/elevation_compat"
+            android:theme="@style/ElevationCompatTheme"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
     </android.support.design.widget.CoordinatorLayout>
 
     <include layout="@layout/include_fab" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -76,6 +76,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                android:background="@drawable/elevation_compat"
+                android:theme="@style/ElevationCompatTheme"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
         </android.support.design.widget.CoordinatorLayout>
 
         <include layout="@layout/include_fab" />

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -10,6 +10,12 @@
         android:layout_height="?actionBarSize"
         android:layout_alignParentTop="true" />
 
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="4dp"
+        android:background="@drawable/elevation_compat"
+        android:theme="@style/ElevationCompatTheme"/>
+
     <FrameLayout
         android:id="@+id/container"
         android:background="?bg_color"

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -11,4 +11,8 @@
     <style name="ListItemBgColor.Dark">
         <item name="android:background">@drawable/list_item_bg_dark</item>
     </style>
+
+    <style name="ElevationCompatTheme">
+        <item name="android:visibility">gone</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,4 +15,7 @@
         <item name="android:textCursorDrawable">@drawable/searchview_cursor</item>
     </style>
 
+    <style name="ElevationCompatTheme">
+        <item name="android:visibility">visible</item>
+    </style>
 </resources>


### PR DESCRIPTION
I noticed that the toolbar doesn’t have a shadow if the device isn’t running lollipop and added a workaround for that. I’m not sure if the added complexity is worth it, I’ll let you decide!
